### PR TITLE
Update dead manual installation url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jitsi Meet in docker
 
-Implemented based on [Jitsi Meet manual installation instructions](https://github.com/jitsi/jitsi-meet/blob/master/doc/manual-install.md).
+Implemented based on [Jitsi Meet manual installation instructions](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-manual).
 
 ## Images
 


### PR DESCRIPTION
The README was deleted in this commit https://github.com/jitsi/jitsi-meet/commit/7c4c8384fd8309518ac925d77224d6a98fcd9fb1#diff-9a09b4dfda82e3e665e31092d1c3ec8d . 

Upstream moved the README contents to their website.

old link: https://github.com/jitsi/jitsi-meet/blob/262e85526048b171a106cd66fd683cec0c7a75f3/doc/manual-install.md
new link: https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-manual